### PR TITLE
feat(relayer): configurable gas price escalator

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/config.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/config.rs
@@ -109,6 +109,17 @@ pub struct TransactionOverrides {
 
     /// Gas price cap, in wei.
     pub gas_price_cap: Option<U256>,
+
+    /// Weight of the previous gas price used when calculating the TWAP for
+    /// the gas price escalator.
+    pub gas_escalator_history_weight: Option<U256>,
+    /// Weight of the latest gas price sample used when calculating the TWAP
+    /// for the gas price escalator.
+    pub gas_escalator_current_weight: Option<U256>,
+    /// Multiplier denominator applied when escalating gas prices.
+    pub gas_escalator_multiplier_denominator: Option<U256>,
+    /// Multiplier numerator applied when escalating gas prices.
+    pub gas_escalator_multiplier_numerator: Option<U256>,
 }
 
 /// Ethereum reorg period

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -114,6 +114,27 @@ pub fn build_ethereum_connection_conf(
                 .get_opt_key("gasPriceCap")
                 .parse_u256()
                 .end(),
+
+            gas_escalator_history_weight: value_parser
+                .chain(err)
+                .get_opt_key("gasEscalatorHistoryWeight")
+                .parse_u256()
+                .end(),
+            gas_escalator_current_weight: value_parser
+                .chain(err)
+                .get_opt_key("gasEscalatorCurrentWeight")
+                .parse_u256()
+                .end(),
+            gas_escalator_multiplier_denominator: value_parser
+                .chain(err)
+                .get_opt_key("gasEscalatorMultiplierDenominator")
+                .parse_u256()
+                .end(),
+            gas_escalator_multiplier_numerator: value_parser
+                .chain(err)
+                .get_opt_key("gasEscalatorMultiplierNumerator")
+                .parse_u256()
+                .end(),
         })
         .unwrap_or_default();
 

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
@@ -42,7 +42,7 @@ use super::{
     EthereumTxPrecursor,
 };
 
-use gas_price::GasPrice;
+use gas_price::{GasEscalatorConfig, GasPrice};
 
 mod gas_limit_estimator;
 mod gas_price;
@@ -140,8 +140,12 @@ impl EthereumAdapter {
         .await;
 
         // then, compare the estimated gas price with `current * escalation_multiplier`
-        let escalated_gas_price =
-            gas_price::escalate_gas_price_if_needed(&old_gas_price, &estimated_gas_price);
+        let escalator_config = GasEscalatorConfig::from(&self.transaction_overrides);
+        let escalated_gas_price = gas_price::escalate_gas_price_if_needed(
+            &old_gas_price,
+            &estimated_gas_price,
+            &escalator_config,
+        );
 
         let new_gas_price = match escalated_gas_price {
             GasPrice::None => estimated_gas_price,

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter/gas_price.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter/gas_price.rs
@@ -1,4 +1,4 @@
-pub use escalator::escalate_gas_price_if_needed;
+pub use escalator::{escalate_gas_price_if_needed, GasEscalatorConfig};
 pub use estimator::estimate_gas_price;
 pub use price::{extract_gas_price, GasPrice};
 

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter/gas_price/escalator.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter/gas_price/escalator.rs
@@ -3,18 +3,61 @@ use ethers_core::types::transaction::eip2718::TypedTransaction;
 use tracing::{debug, error, info, warn};
 
 use hyperlane_core::U256;
+use hyperlane_ethereum::TransactionOverrides;
 
 use crate::adapter::EthereumTxPrecursor;
 
 use super::price::GasPrice;
 
-const ESCALATION_MULTIPLIER_NUMERATOR: u32 = 110;
-const ESCALATION_MULTIPLIER_DENOMINATOR: u32 = 100;
+/// Configuration for the gas price escalator.
+#[derive(Clone, Copy, Debug)]
+pub struct GasEscalatorConfig {
+    pub escalation_multiplier_numerator: u32,
+    pub escalation_multiplier_denominator: u32,
+    pub twap_history_weight: u32,
+    pub twap_current_weight: u32,
+}
+
+impl Default for GasEscalatorConfig {
+    fn default() -> Self {
+        Self {
+            escalation_multiplier_numerator: 110,
+            escalation_multiplier_denominator: 100,
+            twap_history_weight: 3,
+            twap_current_weight: 1,
+        }
+    }
+}
+
+impl From<&TransactionOverrides> for GasEscalatorConfig {
+    fn from(overrides: &TransactionOverrides) -> Self {
+        let default = GasEscalatorConfig::default();
+        Self {
+            escalation_multiplier_numerator: overrides
+                .gas_escalator_multiplier_numerator
+                .map(|v| v.as_u32())
+                .unwrap_or(default.escalation_multiplier_numerator),
+            escalation_multiplier_denominator: overrides
+                .gas_escalator_multiplier_denominator
+                .map(|v| v.as_u32())
+                .unwrap_or(default.escalation_multiplier_denominator),
+            twap_history_weight: overrides
+                .gas_escalator_history_weight
+                .map(|v| v.as_u32())
+                .unwrap_or(default.twap_history_weight),
+            twap_current_weight: overrides
+                .gas_escalator_current_weight
+                .map(|v| v.as_u32())
+                .unwrap_or(default.twap_current_weight),
+        }
+    }
+}
 
 /// Sets the max between the newly estimated gas price and 1.1x the old gas price.
 pub fn escalate_gas_price_if_needed(
     old_gas_price: &GasPrice,
     estimated_gas_price: &GasPrice,
+    config: &GasEscalatorConfig,
 ) -> GasPrice {
     // assumes the old and new txs have the same type
     match (old_gas_price, estimated_gas_price) {
@@ -45,7 +88,7 @@ pub fn escalate_gas_price_if_needed(
             },
         ) => {
             let escalated_gas_price =
-                get_escalated_price_from_old_and_new(old_gas_price, estimated_gas_price);
+                get_escalated_price_from_old_and_new(old_gas_price, estimated_gas_price, config);
             debug!(
                 tx_type = "Legacy or Eip2930",
                 ?old_gas_price,
@@ -68,10 +111,13 @@ pub fn escalate_gas_price_if_needed(
             },
         ) => {
             let escalated_max_fee_per_gas =
-                get_escalated_price_from_old_and_new(old_max_fee, new_max_fee);
+                get_escalated_price_from_old_and_new(old_max_fee, new_max_fee, config);
 
-            let escalated_max_priority_fee_per_gas =
-                get_escalated_price_from_old_and_new(old_max_priority_fee, new_max_priority_fee);
+            let escalated_max_priority_fee_per_gas = get_escalated_price_from_old_and_new(
+                old_max_priority_fee,
+                new_max_priority_fee,
+                config,
+            );
 
             debug!(
                 tx_type = "Eip1559",
@@ -94,13 +140,62 @@ pub fn escalate_gas_price_if_needed(
     }
 }
 
-fn get_escalated_price_from_old_and_new(old_gas_price: &U256, new_gas_price: &U256) -> U256 {
-    let escalated_gas_price = apply_escalation_multiplier(old_gas_price);
-    escalated_gas_price.max(*new_gas_price)
+fn get_escalated_price_from_old_and_new(
+    old_gas_price: &U256,
+    new_gas_price: &U256,
+    config: &GasEscalatorConfig,
+) -> U256 {
+    // Blend the previous gas price with the most recently estimated gas price to
+    // form a simple TWAP. This smooths out short lived spikes in the oracle and
+    // prevents the escalator from growing without bound when prices are
+    // volatile.
+    let history_weight = U256::from(config.twap_history_weight);
+    let current_weight = U256::from(config.twap_current_weight);
+    let blended = (*old_gas_price * history_weight + *new_gas_price * current_weight)
+        / (history_weight + current_weight);
+
+    // Apply the escalation multiplier to the blended price and the oracle price
+    // to protect against stale oracle data.
+    let escalated_from_history = apply_escalation_multiplier(&blended, config);
+    let escalated_from_oracle = apply_escalation_multiplier(new_gas_price, config);
+    escalated_from_history.max(escalated_from_oracle)
 }
 
-fn apply_escalation_multiplier(gas_price: &U256) -> U256 {
-    let numerator = U256::from(ESCALATION_MULTIPLIER_NUMERATOR);
-    let denominator = U256::from(ESCALATION_MULTIPLIER_DENOMINATOR);
+fn apply_escalation_multiplier(gas_price: &U256, config: &GasEscalatorConfig) -> U256 {
+    let numerator = U256::from(config.escalation_multiplier_numerator);
+    let denominator = U256::from(config.escalation_multiplier_denominator);
     gas_price * numerator / denominator
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn twap_escalates_beyond_new_price() {
+        let old = U256::from(200_000u64);
+        let oracle = U256::from(219_000u64);
+        let config = GasEscalatorConfig::default();
+        let escalated = get_escalated_price_from_old_and_new(&old, &oracle, &config);
+
+        // With the TWAP weighting the escalation still ensures we pay above the
+        // latest oracle price.
+        assert_eq!(escalated, U256::from(240_900u64));
+    }
+
+    #[test]
+    fn config_overrides_defaults() {
+        let overrides = TransactionOverrides {
+            gas_escalator_multiplier_numerator: Some(200u32.into()),
+            gas_escalator_multiplier_denominator: Some(100u32.into()),
+            gas_escalator_history_weight: Some(1u32.into()),
+            gas_escalator_current_weight: Some(1u32.into()),
+            ..Default::default()
+        };
+
+        let config = GasEscalatorConfig::from(&overrides);
+        assert_eq!(config.escalation_multiplier_numerator, 200);
+        assert_eq!(config.twap_history_weight, 1);
+        assert_eq!(config.twap_current_weight, 1);
+    }
 }


### PR DESCRIPTION
## Summary
- allow configuring gas price TWAP weights and escalation multiplier
- always escalate beyond latest oracle price to guard against bad readings
- parse new escalator options from chain connection settings

## Testing
- `cargo test -p lander twap_escalates_beyond_new_price` *(fails: build did not finish in the allotted time)*


------
https://chatgpt.com/codex/tasks/task_e_689379b620348321ae400519cada5118